### PR TITLE
Fix sbt name & dependencies

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,7 +1,11 @@
-name := "dicebot"
+name := "funbot"
 
 version := "1.0"
 
 scalaVersion := "2.11.8"
 
-libraryDependencies += "org.scalatest" %% "scalatest" % "2.2.6" % "test"
+libraryDependencies ++= Seq(
+  "org.scala-lang" % "scala-reflect" % "2.11.8",
+  "org.scala-lang.modules" % "scala-xml_2.11" % "1.0.4",
+  "org.scalatest" %% "scalatest" % "2.2.6" % "test"
+)


### PR DESCRIPTION
1. sbt project를 intellij 에서 import 해보니 아래와 같이 warning 발생해서 상위 버전으로 dependencies 지정하였습니다. 

```
[warn] Multiple dependencies with the same organization/name but different versions. To avoid conflict, pick one version:
[warn]  * org.scala-lang:scala-reflect:(2.11.7, 2.11.8)
[warn]  * org.scala-lang.modules:scala-xml_2.11:(1.0.2, 1.0.4)
```
1. name 변경했습니다. 
