### PR TITLE
DiceBot 클래스에서 Null Guard Clause 제거

### DIFF
--- a/src/main/scala/DiceBot.scala
+++ b/src/main/scala/DiceBot.scala
@@ -1,8 +1,6 @@
 import scala.util.Random
 
 class DiceBot(val random: Random) {
-  require(random != null, "the 'random' value cannot be null.")
-
   private lazy val regex = """(?i)\s*roll\s+(\d+)d(\d+)\s*""".r
 
   /** Processes an `input` to return sequential string values
@@ -17,9 +15,6 @@ class DiceBot(val random: Random) {
     */
   def process(input: String): Option[String] =
     input match {
-      case null =>
-        throw new IllegalArgumentException(
-          "the 'input' value cannot be null.")
       case regex(count, max) =>
         Some(makeOrderString(count.toInt, max.toInt))
       case _ =>

--- a/src/test/scala/DiceBotTest.scala
+++ b/src/test/scala/DiceBotTest.scala
@@ -2,17 +2,6 @@ import org.scalatest.FunSuite
 import scala.util.Random
 
 class DiceBotTest extends FunSuite {
-  test("constructor with null random throws") {
-    val thrown = intercept[IllegalArgumentException](new DiceBot(null))
-    assert(thrown != null)
-  }
-
-  test("process with null input throws") {
-    val thrown = intercept[IllegalArgumentException](
-      new DiceBot(new Random).process(null))
-    assert(thrown != null)
-  }
-
   Seq(
     "invalid string",
     "",


### PR DESCRIPTION
이 PR은 #5 구현과 관련되어 있습니다.

@myeesan PR #22 가 merge 되면서 못다한 논의를 여기서 했으면 합니다. 얘기나온 주제를 정리하자면 아래 두 가지인걸로 알고 있습니다.
- [x] null 방어구문

<s>\- [ ] 테스트를 위한 의존성 주입</s> (따로 처리하겠습니다.)

먼저 null 방어구문에 대해 먼저 얘기나눠볼까 합니다.

> null 은 좀 더 이야기 해 봐야 할 것 같습니다. 자바에서 호출 되는 것을 고려한다면 null 체크가 필요하겠지만 스칼라에서는 null을 사용하지 않는 것을 기본 관례입니다. 예를 들면, scala lint check 를 수행할 때 옵션에서 null을 disable 하는 것이 기본 설정입니다. 따라서, null체크는 배제하는 것이 코드를 간결하게 하며, null 오류는 관례에 의해 방지되도록 하는 것이 좋을 것 같습니다.

 null을 사용하지 말자라고 약속을 관례적으로 할지라도 `String`, `Random` 과 같은 참조타입의 파라메타에 대해서는 null을 넘겨줄 수 있다는 생각합니다. 그래서 방어 구문이 필요하지 않을까라는게 제 생각이었습니다. "null 오류는 관례에 의해 방지되도록 하는 것이 좋다" 라고 말씀하신게 제 생각과 연관된 얘기 같은데, 제가 몰라서 이해를 못하고 있습니다.
